### PR TITLE
Updating perf counter instance name matching

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/ProcessInstanceNameCache.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/ProcessInstanceNameCache.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                 PerformanceCounterCategory category = new PerformanceCounterCategory(counterConfiguration.ProcessIdCounterCategory);
 
                 string[] processInstanceNames = category.GetInstanceNames()
-                    .Where(inst => inst.StartsWith(currentProcess.ProcessName))
+                    .Where(inst => inst.ToLowerInvariant().StartsWith(currentProcess.ProcessName.ToLowerInvariant()))
                     .ToArray();
 
                 foreach (string processInstanceName in processInstanceNames)


### PR DESCRIPTION
When creating perf counters with instances the input was not matching any existing instances as the category was reporting them in lower case.

```
// Creating perf counters
var counter = new PerformanceCounter(category.CategoryName, c.CounterName, $"{processName}_{processId}", false);
// Should be Myapp.Host.Console.vshost_10732
...
PerformanceCounterCategory cat = new PerformanceCounterCategory("MyAppCategory");
cat.GetInstanceNames();
// {string[1]}
// [1]: "myapp.host.console.vshost_10732"